### PR TITLE
don't send "You are not authorized to use this bot" when message sent by bot itself

### DIFF
--- a/src/bot/plugins/commands.py
+++ b/src/bot/plugins/commands.py
@@ -10,7 +10,7 @@ from ...configs.user import User
 from ...translator import Translator, Strings
 
 
-@Client.on_message(~custom_filters.check_user_filter)
+@Client.on_message(~filters.me & ~custom_filters.check_user_filter)
 async def access_denied_message(client: Client, message: Message) -> None:
     button = InlineKeyboardMarkup(
         [


### PR DESCRIPTION
Now it reacts on commands that was sent by bot